### PR TITLE
Fix module version mismatch for Beta API

### DIFF
--- a/BP/manifest.json
+++ b/BP/manifest.json
@@ -43,13 +43,13 @@
 		}
 	],
 	"dependencies": [
-		{
-			"module_name": "@minecraft/server",
-			"version": "2.0.0-beta"
-		},
-		{
-			"module_name": "@minecraft/server-ui",
-			"version": "2.0.0-beta"
-		}
-	]
+                {
+                        "module_name": "@minecraft/server",
+                        "version": "2.1.0-beta"
+                },
+                {
+                        "module_name": "@minecraft/server-ui",
+                        "version": "2.1.0-beta"
+                }
+        ]
 }

--- a/builds/dist/Mystical Agriculture [RP] (dev) BP/manifest.json
+++ b/builds/dist/Mystical Agriculture [RP] (dev) BP/manifest.json
@@ -43,13 +43,13 @@
 		}
 	],
 	"dependencies": [
-		{
-			"module_name": "@minecraft/server",
-			"version": "2.0.0-beta"
-		},
-		{
-			"module_name": "@minecraft/server-ui",
-			"version": "2.0.0-beta"
-		}
-	]
+                {
+                        "module_name": "@minecraft/server",
+                        "version": "2.1.0-beta"
+                },
+                {
+                        "module_name": "@minecraft/server-ui",
+                        "version": "2.1.0-beta"
+                }
+        ]
 }


### PR DESCRIPTION
## Summary
- update `BP/manifest.json` to use `@minecraft/server` and `server-ui` version `2.1.0-beta`
- update the same dependencies in the dist manifest

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688261bcfcbc8321a7202e2623f74576